### PR TITLE
Default worker count to the number of processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Speed up Manifest::Compile by forking processes
 
 ## Usage
 
+To override the number of processes you can use the
+`SPROCKETS_DERAILLEUR_WORKER_COUNT` environment variable. It defaults to the
+number of processors on your machine.
+
 ### Rails 4.0
 
-Just drop in the Gemfile, nothing more. To override the number of processes you
-can use the `SPROCKETS_DERAILLEUR_WORKER_COUNT` environment variable. It
-defaults to the number of processors on your machine.
+Just drop in the Gemfile, nothing more.
 
 ### Rails 3.2
 
@@ -28,15 +30,11 @@ module Sprockets
   
     alias_method :compile_without_manifest, :compile
     def compile
-    
-      # Determine how many workers you want to use first. Determine the number of physical CPUs this way
-      processes = SprocketsDerailleur::number_of_processors rescue 1
-      
-      puts "Multithreading on " + processes.to_s + " processors"
+      puts "Multithreading on " + SprocketsDerailleur.worker_count + " processors"
       puts "Starting Asset Compile: " + Time.now.getutc.to_s
       
       # Then initialize the manifest with the workers you just determined
-      manifest = Sprockets::Manifest.new(env, target, processes)
+      manifest = Sprockets::Manifest.new(env, target)
       manifest.compile paths
       
       puts "Finished Asset Compile: " + Time.now.getutc.to_s

--- a/lib/sprockets-derailleur.rb
+++ b/lib/sprockets-derailleur.rb
@@ -24,7 +24,7 @@ module SprocketsDerailleur
     raise "can't determine 'number_of_processors' for '#{RUBY_PLATFORM}'"
   end
 
-  def self.default_worker_count
+  def self.worker_count
     worker_count = ENV['SPROCKETS_DERAILLEUR_WORKER_COUNT'].to_i
     return worker_count if worker_count > 0
     number_of_processors

--- a/lib/sprockets-derailleur/manifest.rb
+++ b/lib/sprockets-derailleur/manifest.rb
@@ -2,16 +2,9 @@ require "sprockets"
 
 module Sprockets
   class Manifest
-    attr_reader :workers
-
-    alias_method :old_initialize, :initialize
-    def initialize(environment, path, workers=SprocketsDerailleur::default_worker_count)
-      @workers = workers
-      old_initialize(environment, path)
-    end
-
     alias_method :compile_with_workers, :compile
     def compile(*args)
+      worker_count = SprocketsDerailleur::worker_count
       paths_with_errors = {}
 
       time = Benchmark.measure do
@@ -30,10 +23,10 @@ module Sprockets
           end
         end
 
-        logger.warn "Initializing #{@workers} workers"
+        logger.warn "Initializing #{worker_count} workers"
 
         workers = []
-        @workers.times do
+        worker_count.times do
           workers << worker(paths)
         end
 


### PR DESCRIPTION
This allows sprockets-derailleur to be dropped into a rails 4 project
and "just work". You can also override the worker count with an
environment variable.
