### PR TITLE
Add thread safe file store

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,28 @@ rake assets:precompile:primary RAILS_ENV=production
 
 This skips the non-digest compile, hence doubling speed (especially useful if syncing assets with a remote server).
 
+## Troubleshooting
+
+In some situations (like if you are using compass sprites) you may see
+occasional exceptions such as:
+
+```
+lib/active_support/core_ext/marshal.rb:6:in `load': end of file reached (EOFError)
+
+AND/OR
+
+lib/sprockets-derailleur/manifest.rb:127:in `write': Broken pipe (Errno::EPIPE)
+```
+
+The default cache is not safe for parallel, you can override it by adding the
+following to `config/application.rb`:
+
+```ruby
+config.assets.configure do |env|
+  env.cache = SprocketsDerailleur::FileStore.new("tmp/cache/assets")
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/sprockets-derailleur.rb
+++ b/lib/sprockets-derailleur.rb
@@ -1,5 +1,6 @@
 require "sprockets-derailleur/version"
 require "sprockets-derailleur/manifest"
+require "sprockets-derailleur/file_store"
 
 module SprocketsDerailleur
   def self.number_of_processors
@@ -11,7 +12,7 @@ module SprocketsDerailleur
       # this works for windows 2000 or greater
       require 'win32ole'
       wmi = WIN32OLE.connect("winmgmts://")
-      wmi.ExecQuery("select * from Win32_ComputerSystem").each do |system| 
+      wmi.ExecQuery("select * from Win32_ComputerSystem").each do |system|
         begin
           processors = system.NumberOfLogicalProcessors
         rescue

--- a/lib/sprockets-derailleur/file_store.rb
+++ b/lib/sprockets-derailleur/file_store.rb
@@ -1,0 +1,32 @@
+require 'fileutils'
+require 'timeout'
+
+# The Sprockets::Cache::FileStore is not thread/parallel safe.
+# This one uses file locks to be safe.
+module SprocketsDerailleur
+  class FileStore < Sprockets::Cache::FileStore
+    def lock
+      @lock ||= begin
+        FileUtils.mkdir_p @root
+        File.open(@root.join("lock"), File::RDWR|File::CREAT)
+      end
+    end
+
+    # Lookup value in cache
+    def [](key)
+      with_lock(File::LOCK_SH) { super }
+    end
+
+    # Save value to cache
+    def []=(key, value)
+      with_lock(File::LOCK_EX) { super }
+    end
+
+    def with_lock(type)
+      Timeout::timeout(1) { lock.flock(type) }
+      yield
+    ensure
+      lock.flock(File::LOCK_UN)
+    end
+  end
+end


### PR DESCRIPTION
The default one from sprockets is not thread/parallel safe. This one
uses locks to be safe so it can safely be used with things like compass
sprites or other things that may cause race conditions in larger
projects.
