### PR TITLE
Update file store timeout value

### DIFF
--- a/lib/sprockets-derailleur/file_store.rb
+++ b/lib/sprockets-derailleur/file_store.rb
@@ -23,7 +23,7 @@ module SprocketsDerailleur
     end
 
     def with_lock(type)
-      Timeout::timeout(1) { lock.flock(type) }
+      Timeout::timeout(10) { lock.flock(type) }
       yield
     ensure
       lock.flock(File::LOCK_UN)


### PR DESCRIPTION
After upgrading from rails 3 to rails 4 we hit timeout error with the file store lock. We're compiling assets on a 32core machine, so that doesn't give much time given the timeout is only 1000ms. Raising the timeout has fixed this problem for us and doesn't seem to have any ill effects.