### PR TITLE
Add a warning about Sprockets 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Speed up Manifest::Compile by forking processes 
 
+**Warning: Do not use with Sprockets 3+!** (See [#25](https://github.com/steel/sprockets-derailleur/issues/25) for details.)
+
 ## Installation
 
 1. Add this line to your application's Gemfile: `gem 'sprockets-derailleur'`


### PR DESCRIPTION
Per #25, this gem doesn't work correctly with Sprockets 3, and the failure won't be apparent until after deploy. Users should be warned so they don't get themselves into trouble.