### PR TITLE
Correctly gzip bundled assets in Sprockets 2

### DIFF
--- a/lib/sprockets-derailleur/manifest.rb
+++ b/lib/sprockets-derailleur/manifest.rb
@@ -157,7 +157,7 @@ module Sprockets
 
     def skip_gzip?(asset)
       if sprockets2?
-        asset.is_a?(BundledAsset)
+        !asset.is_a?(BundledAsset)
       else
         environment.skip_gzip?
       end


### PR DESCRIPTION
When using sprockets 2, everything but the bundled assets was being gzipped. A regression that came up [here](https://github.com/steel/sprockets-derailleur/pull/24/files#diff-983226e13b22fed9d42438f9b1ffaef7R117).