### PR TITLE
FIX: vuln in a dep (sprockets)

### DIFF
--- a/sprockets-derailleur.gemspec
+++ b/sprockets-derailleur.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'sprockets', '>= 2'
+  gem.add_dependency 'sprockets', '>= 2.12.5'
 end


### PR DESCRIPTION
A vulnerability has been discovered in sprockets.

![image](https://user-images.githubusercontent.com/12163506/41630757-0a94a548-7474-11e8-8fa6-81251ddde75a.png)

In our continuous integration pipeline we use ruby-advisory-db to find vulnerabilities. This is how we were alerted. We have moved onto a fork of this gem in the meantime.

Please let me know if there is any other changes required in this PR to have it merged 👍.